### PR TITLE
Fix redundant directedness arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## **0.5.0** (Unreleased)
+
+-   Housekeeping
+    -   Removed extra arguments to Graph constructor and improved Graph kwargs handing
+    -   Added `grand.DiGraph` convenience wrapper for directed graphs
+
 ## **0.4.2** (May 7, 2022)
 
 -   Backends

--- a/grand/__init__.py
+++ b/grand/__init__.py
@@ -1,16 +1,16 @@
 """
-Grand graph databasifier.
+Grand graphs package.
 
-Aug 2020
 """
 
+from typing import Optional
 from .backends import Backend, NetworkXBackend
 from .dialects import NetworkXDialect, IGraphDialect
 
 
 _DEFAULT_BACKEND = NetworkXBackend
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"
 
 
 class Graph:
@@ -19,32 +19,49 @@ class Graph:
 
     """
 
-    def __init__(
-        self, backend: Backend = None, directed: bool = True, dialects: dict = None
-    ):
+    def __init__(self, backend: Optional[Backend] = None, **backend_kwargs: dict):
         """
         Create a new grand.Graph.
+
+        The only positional argument is the backend to use. All other arguments
+        are passed to the backend's constructor, if a type is provided.
+        Otherwise, kwargs are ignored.
 
         Arguments:
             backend (Backend): The backend to use. If none is provided, will
                 default to _DEFAULT_BACKEND.
 
-        Returns:
-            None
-
         """
-        self.backend = backend or _DEFAULT_BACKEND(directed=directed)
+        self.backend = backend or _DEFAULT_BACKEND
+
+        # If you passed a class instead of an instance, instantiate it with
+        # kwargs from the constructor:
+        if isinstance(self.backend, type):
+            self.backend = self.backend(**backend_kwargs)
 
         # Attach dialects:
         self.nx = NetworkXDialect(self)
         self.igraph = IGraphDialect(self)
 
-        if dialects:
-            self.dialects = {k: v(self) for k, v in dialects.items()}
 
-    def save(self, filename: str) -> str:
-        raise NotImplementedError()
+class DiGraph(Graph):
+    """
+    A grand.DiGraph enables you to manipulate a directed graph. This is a
+    convenience class that inherits from grand.Graph.
 
-    @staticmethod
-    def load(self, filename: str) -> str:
-        raise NotImplementedError()
+    """
+
+    def __init__(self, backend: Optional[Backend] = None, **backend_kwargs: dict):
+        """
+        Create a new grand.DiGraph.
+
+        The only positional argument is the backend to use. All other arguments
+        are passed to the backend's constructor, if a type is provided.
+        Otherwise, kwargs are ignored.
+
+        Arguments:
+            backend (Backend): The backend to use. If none is provided, will
+                default to _DEFAULT_BACKEND.
+
+        """
+        super().__init__(backend, **{**backend_kwargs, "directed": True})

--- a/grand/dialects/__init__.py
+++ b/grand/dialects/__init__.py
@@ -167,6 +167,9 @@ class NetworkXDialect(nx.Graph):
     def out_degree(self, nbunch=None):
         return self.parent.backend.out_degrees(nbunch)
 
+    def is_directed(self):
+        return self.parent.backend.is_directed()
+
 
 class IGraphDialect(nx.Graph):
     """

--- a/grand/dialects/test_dialect.py
+++ b/grand/dialects/test_dialect.py
@@ -22,6 +22,13 @@ class TestNetworkXDialect(unittest.TestCase):
         H.add_edge("1", "3")
         self.assertEqual(G.nx.pred, H.pred)
 
+    def test_nx_directed(self):
+        G = Graph(directed=True)
+        self.assertTrue(G.nx.is_directed())
+
+        G = Graph(directed=False)
+        self.assertFalse(G.nx.is_directed())
+
     def test_in_degree(self):
         G = Graph(directed=True)
         G.nx.add_edge("1", "2")

--- a/grand/test_graph.py
+++ b/grand/test_graph.py
@@ -1,6 +1,6 @@
 import unittest
 
-from . import Graph, NetworkXBackend
+from . import Graph, DiGraph
 
 
 class TestGraph(unittest.TestCase):
@@ -10,3 +10,7 @@ class TestGraph(unittest.TestCase):
     def test_can_use_nx_backend(self):
         Graph().nx
 
+    def test_can_create_directed(self):
+        assert Graph(directed=True).nx.is_directed() is True
+        assert Graph(directed=False).nx.is_directed() is False
+        assert DiGraph().nx.is_directed() is True


### PR DESCRIPTION
This removes the possibility of doing silly things like

```
from grand import Graph
from grand.backends import NetworkXBackend

# No longer broken:
Graph(directed=True, backend=NetworkXBackend(directed=False)
```