### PR TITLE
Add remove_node method to SQLBackend

### DIFF
--- a/grand/backends/_sqlbackend.py
+++ b/grand/backends/_sqlbackend.py
@@ -191,25 +191,25 @@ class SQLBackend(Backend):
                 parameters={self._primary_key: node_name, "_metadata": metadata},
             )
 
-    def remove_node(self, name: Hashable) -> None:
+    def remove_node(self, u: Hashable) -> None:
         """
         Removes nodes and related edges for name.
 
         Args:
-            node_name (Hashable): id of the node
+            u (Hashable): id of the node
         """
 
         # Remove nodes
         statement = delete(self._node_table).where(
-            self._node_table.c[self._primary_key] == str(name)
+            self._node_table.c[self._primary_key] == str(u)
         )
         self._connection.execute(statement)
 
         # Remove edges for node
         statement = delete(self._edge_table).where(
             or_(
-                self._edge_table.c[self._edge_source_key] == str(name),
-                self._edge_table.c[self._edge_target_key] == str(name)
+                self._edge_table.c[self._edge_source_key] == str(u),
+                self._edge_table.c[self._edge_target_key] == str(u)
             )
         )
         self._connection.execute(statement)

--- a/grand/backends/_sqlbackend.py
+++ b/grand/backends/_sqlbackend.py
@@ -255,7 +255,7 @@ class SQLBackend(Backend):
                     self._node_table.c[self._primary_key] == str(u)
                 )
             ).fetchall()
-        )
+        ) > 0
 
     def add_edge(self, u: Hashable, v: Hashable, metadata: dict):
         """

--- a/grand/backends/test_backends.py
+++ b/grand/backends/test_backends.py
@@ -151,6 +151,17 @@ class TestBackendPersistence:
         nodes = list(backend.all_nodes_as_iterable())
         # assert
         assert node0 in nodes
+
+        # test remove_node
+        backend = SQLBackend(db_url=url, directed=True)
+        node1, node2 = backend.add_node("A", {}), backend.add_node("B", {})
+        backend.add_edge(node1, node2, {})
+        assert backend.has_node(node1)
+        assert backend.has_edge(node1, node2)
+        backend.remove_node(node1)
+        assert not backend.has_node(node1)
+        assert not backend.has_edge(node1, node2)
+
         # cleanup
         os.remove(dbpath)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
         "sql": ["SQLAlchemy>=1.3"],
         "dynamodb": ["boto3"],
         "igraph": ["igraph"],
-        "networkit": ["cmake", "cython", "networkit"],
+        "networkit": ["cmake", "cython", "networkit", "numpy<2.0.0"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR makes the following changes:

- Adds `remove_node` method to the `SQLBackend` per the `NetworkXDialect`
- Changes setup.py to limit numpy < 2.0 when using the `networkit` extra
- Changes `has_node` to return a bool vs int to conform with dialect standard
