### PR TITLE
Fix bug with get_node_by_id

### DIFF
--- a/grand/backends/_sqlbackend.py
+++ b/grand/backends/_sqlbackend.py
@@ -350,16 +350,16 @@ class SQLBackend(Backend):
 
         """
 
-        res = (
-            self._connection.execute(
-                self._node_table.select().where(
-                    self._node_table.c[self._primary_key] == str(node_name)
-                )
+        res = self._connection.execute(
+            self._node_table.select().where(
+                self._node_table.c[self._primary_key] == str(node_name)
             )
-            .fetchone()
-            ._metadata
-        )
-        return res
+        ).fetchone()
+
+        if res:
+            return res._metadata
+
+        raise KeyError(f"Node {node_name} not found")
 
     def get_edge_by_id(self, u: Hashable, v: Hashable):
         """

--- a/grand/backends/backend.py
+++ b/grand/backends/backend.py
@@ -339,6 +339,7 @@ class InMemoryCachedBackend(CachedBackend):
         "add_edge",
         "add_edges_from",
         "ingest_from_edgelist_dataframe",
+        "remove_node"
     ]
 
     _default_write_methods = [
@@ -347,6 +348,7 @@ class InMemoryCachedBackend(CachedBackend):
         "add_edge",
         "add_edges_from",
         "ingest_from_edgelist_dataframe",
+        "remove_node"
     ]
 
     def __init__(

--- a/grand/backends/test_backends.py
+++ b/grand/backends/test_backends.py
@@ -161,6 +161,8 @@ class TestBackendPersistence:
         backend.remove_node(node1)
         assert not backend.has_node(node1)
         assert not backend.has_edge(node1, node2)
+        with pytest.raises(KeyError):
+            assert not backend.get_node_by_id(node1)
 
         # cleanup
         os.remove(dbpath)


### PR DESCRIPTION
I noticed a couple other things while testing as follows:

- Fix bug with `get_node_by_id`. This makes the behavior consistent with `get_edge_by_id`.
- This PR also adds `remove_node` to writable methods for `InMemoryCachedBackend`. This fixes a caching issue when a node is removed.

I want to be respectful of your time, so I can handle these changes locally until you have time to integrate and push a release. Thanks again for all the help!