### PR TITLE
fix: derive edge-only DataFrame nodes correctly

### DIFF
--- a/grand/backends/_dataframe.py
+++ b/grand/backends/_dataframe.py
@@ -146,12 +146,17 @@ class DataFrameBackend(Backend):
             ]
 
         else:
+            nodes = pd.unique(
+                pd.concat(
+                    [
+                        self._edge_df[self._edge_df_source_column],
+                        self._edge_df[self._edge_df_target_column],
+                    ],
+                    ignore_index=True,
+                )
+            )
             return [
-                (node_id, {}) if include_metadata else node_id
-                for node_id in self._edge_df[self._edge_df_source_column]
-            ] + [
-                (node_id, {}) if include_metadata else node_id
-                for node_id in self._edge_df[self._edge_df_target_column]
+                (node_id, {}) if include_metadata else node_id for node_id in nodes
             ]
 
     def has_node(self, u: Hashable) -> bool:
@@ -167,8 +172,8 @@ class DataFrameBackend(Backend):
         if self._node_df is not None:
             return u in self._node_df.index
 
-        return u in (self._edge_df[self._edge_df_source_column]) or u in (
-            self._edge_df[self._edge_df_target_column]
+        return u in self._edge_df[self._edge_df_source_column].values or u in (
+            self._edge_df[self._edge_df_target_column].values
         )
 
     def add_edge(self, u: Hashable, v: Hashable, metadata: dict):
@@ -469,10 +474,15 @@ class DataFrameBackend(Backend):
         """
         if self._node_df is not None:
             return len(self._node_df)
-        # Return number of unique sources intersected with number of unique targets
         return len(
-            set(self._edge_df[self._edge_df_source_column]).intersection(
-                set(self._edge_df[self._edge_df_target_column])
+            pd.unique(
+                pd.concat(
+                    [
+                        self._edge_df[self._edge_df_source_column],
+                        self._edge_df[self._edge_df_target_column],
+                    ],
+                    ignore_index=True,
+                )
             )
         )
 

--- a/grand/backends/test_backends.py
+++ b/grand/backends/test_backends.py
@@ -565,6 +565,30 @@ class TestDataFrameBackend:
         assert b.get_edge_count() == 5
         assert b.get_node_count() == 5
 
+    def test_edge_only_nodes_are_unique_members_and_counted_from_union(self):
+        edges = pd.DataFrame(
+            {
+                "source": ["A", "B", "A"],
+                "target": ["B", "C", "B"],
+            }
+        )
+        backend = DataFrameBackend(
+            edge_df=edges,
+            edge_df_source_column="source",
+            edge_df_target_column="target",
+        )
+
+        assert backend.all_nodes_as_iterable() == ["A", "B", "C"]
+        assert backend.all_nodes_as_iterable(include_metadata=True) == [
+            ("A", {}),
+            ("B", {}),
+            ("C", {}),
+        ]
+        assert backend.has_node("A")
+        assert backend.has_node("C")
+        assert not backend.has_node("missing")
+        assert backend.get_node_count() == 3
+
 
 def test_networkx_can_ingest_edgelist_dataframe():
     backend = NetworkXBackend(directed=True)


### PR DESCRIPTION
## Summary
- derive edge-only nodes from the unique source/target union
- check endpoint values rather than pandas row indexes for membership
- report accurate node counts without a separate node dataframe
- cover custom columns, stable enumeration, metadata mode, and missing nodes