### PR TITLE
fix: return undirected DataFrame predecessors

### DIFF
--- a/grand/backends/_dataframe.py
+++ b/grand/backends/_dataframe.py
@@ -417,7 +417,7 @@ class DataFrameBackend(Backend):
                 return {
                     (
                         r[self._edge_df_target_column]
-                        if r[self._edge_df_target_column] != u
+                        if r[self._edge_df_source_column] == u
                         else r[self._edge_df_source_column]
                     ): self._edge_as_dict(r)
                     for _, r in self._edge_df[
@@ -450,9 +450,9 @@ class DataFrameBackend(Backend):
             return iter(
                 [
                     (
-                        row[self._edge_df_source_column]
-                        if row[self._edge_df_target_column] != u
-                        else row[self._edge_df_target_column]
+                        row[self._edge_df_target_column]
+                        if row[self._edge_df_source_column] == u
+                        else row[self._edge_df_source_column]
                     )
                     for _, row in self._edge_df[
                         (self._edge_df[self._edge_df_target_column] == u)

--- a/grand/backends/test_backends.py
+++ b/grand/backends/test_backends.py
@@ -338,11 +338,6 @@ class TestBackend:
             NetworkXBackend,
             "NetworkX undirected predecessor support is not implemented",
         )
-        xfail_backend(
-            backend,
-            DataFrameBackend,
-            "APL #77: undirected predecessors return self",
-        )
         b = backend(directed=False, **kwargs)
         b.add_edge("A", "B", {"weight": 1})
 
@@ -588,6 +583,17 @@ class TestDataFrameBackend:
         assert backend.has_node("C")
         assert not backend.has_node("missing")
         assert backend.get_node_count() == 3
+
+    def test_undirected_predecessors_return_opposite_endpoint_with_metadata(self):
+        backend = DataFrameBackend(directed=False)
+        backend.add_edge("A", "B", {"weight": 1})
+        backend.add_edge("C", "A", {"weight": 2})
+
+        assert set(backend.get_node_predecessors("A")) == {"B", "C"}
+        assert backend.get_node_predecessors("A", include_metadata=True) == {
+            "B": {"weight": 1},
+            "C": {"weight": 2},
+        }
 
 
 def test_networkx_can_ingest_edgelist_dataframe():


### PR DESCRIPTION
## Summary
- return the endpoint opposite the queried node for undirected predecessors
- apply the same endpoint selection in metadata mode
- restore DataFrame coverage in the shared predecessor contract
- cover both stored edge orientations and metadata values