### PR TITLE
fix: isolate cached backend values

### DIFF
--- a/grand/backends/backend.py
+++ b/grand/backends/backend.py
@@ -1,4 +1,6 @@
 import cachetools.func
+from collections.abc import Iterator
+from copy import deepcopy
 from typing import Callable, Hashable, Collection
 import abc
 
@@ -330,6 +332,9 @@ class InMemoryCachedBackend(CachedBackend):
 
     Wraps each call to the Backend with an LRU cache.
 
+    Cache operations are synchronized by cachetools, but calls across methods
+    are not atomic and the wrapped backend defines mutation thread safety.
+
     """
 
     _cache_types = {
@@ -394,8 +399,9 @@ class InMemoryCachedBackend(CachedBackend):
 
         def _dirty_cache_decorator(method_: Callable):
             def dirty_cache_dec_wrapper(*args, **kwargs):
+                result = method_(*args, **kwargs)
                 self.clear_cache()
-                return method_(*args, **kwargs)
+                return result
 
             return dirty_cache_dec_wrapper
 
@@ -419,8 +425,18 @@ class InMemoryCachedBackend(CachedBackend):
                 )
 
     def _wrapped(self, method: str) -> Callable:
-        c = self._cache_factory()(getattr(self.backend, method))
-        return c
+        def snapshot(*args, **kwargs):
+            result = getattr(self.backend, method)(*args, **kwargs)
+            return tuple(result) if isinstance(result, Iterator) else deepcopy(result)
+
+        cached = self._cache_factory()(snapshot)
+
+        def wrapped(*args, **kwargs):
+            return deepcopy(cached(*args, **kwargs))
+
+        wrapped.cache_clear = cached.cache_clear
+        wrapped.cache_info = cached.cache_info
+        return wrapped
 
     def clear_cache(self):
         """

--- a/grand/backends/test_cached_backend.py
+++ b/grand/backends/test_cached_backend.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 from .backend import InMemoryCachedBackend
 from ._networkx import NetworkXBackend
 from ._sqlbackend import SQLBackend
@@ -80,4 +81,41 @@ def test_cache_info():
     cached.get_node_count()
 
     assert cached.cache_info()["get_node_count"].misses == 1
+    assert cached.cache_info()["get_node_count"].hits == 1
+
+
+def test_cached_iterators_can_be_consumed_repeatedly():
+    vanilla = NetworkXBackend()
+    vanilla.add_edge("A", "B", {})
+    cached = InMemoryCachedBackend(vanilla, maxsize=1024, ttl=20)
+
+    assert list(cached.get_node_neighbors("A")) == ["B"]
+    assert list(cached.get_node_neighbors("A")) == ["B"]
+
+
+def test_cached_mutable_values_are_isolated_from_callers():
+    vanilla = NetworkXBackend()
+    vanilla.add_edge("A", "B", {"weight": {"value": 1}})
+    cached = InMemoryCachedBackend(vanilla, maxsize=1024, ttl=20)
+
+    metadata = cached.get_edge_by_id("A", "B")
+    metadata["weight"]["value"] = 99
+
+    assert cached.get_edge_by_id("A", "B") == {"weight": {"value": 1}}
+
+
+def test_failed_writes_do_not_clear_cache():
+    class FailingBackend(NetworkXBackend):
+        def add_node(self, *args, **kwargs):
+            raise RuntimeError("write failed")
+
+    vanilla = FailingBackend()
+    cached = InMemoryCachedBackend(vanilla, maxsize=1024, ttl=20)
+    cached.get_node_count()
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        cached.add_node("A", {})
+
+    assert cached.cache_info()["get_node_count"].hits == 0
+    cached.get_node_count()
     assert cached.cache_info()["get_node_count"].hits == 1


### PR DESCRIPTION
## Summary
- snapshot iterators before caching so repeated reads remain consumable
- deep-copy cached values on storage and return to isolate nested mutation
- invalidate cached reads only after successful backend writes
- document cache synchronization and wrapped-backend concurrency scope