### PR TITLE
Preserve reciprocal edges in the NetworkX dialect

### DIFF
--- a/grand/dialects/__init__.py
+++ b/grand/dialects/__init__.py
@@ -4,10 +4,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .. import Graph
 
-import pandas as pd
-
 import networkx as nx
-from networkx.classes.reportviews import NodeView
+from networkx.classes.reportviews import EdgeView, OutEdgeView
 from networkx.classes.coreviews import AdjacencyView, AtlasView
 
 
@@ -208,6 +206,11 @@ class NetworkXDialect(nx.Graph):
 
     def is_directed(self):
         return self.parent.backend.is_directed()
+
+    @property
+    def edges(self):
+        view = OutEdgeView if self.is_directed() else EdgeView
+        return view(self)
 
     def __len__(self):
         return self.parent.backend.get_node_count()

--- a/grand/dialects/test_dialect.py
+++ b/grand/dialects/test_dialect.py
@@ -3,13 +3,6 @@ import unittest
 
 from .. import Graph
 from ..backends import NetworkXBackend
-from . import (
-    NetworkXDialect,
-    IGraphDialect,
-    NetworkitDialect,
-    _GrandAdjacencyView,
-    _GrandNodeAtlasView,
-)
 import networkx as nx
 
 
@@ -83,13 +76,16 @@ class TestNetworkXDialect(unittest.TestCase):
     def test_nx_edges(self):
         G = Graph(directed=True).nx
         H = nx.DiGraph()
-        G.add_edge("1", "2")
+        G.add_edge("1", "2", direction="forward")
+        G.add_edge("2", "1", direction="reverse")
         G.add_edge("1", "3")
-        H.add_edge("1", "2")
+        H.add_edge("1", "2", direction="forward")
+        H.add_edge("2", "1", direction="reverse")
         H.add_edge("1", "3")
         self.assertEqual(dict(G.edges), dict(H.edges))
         self.assertEqual(dict(G.edges()), dict(H.edges()))
-        self.assertEqual(list(G.edges["1", "2"]), list(H.edges["1", "2"]))
+        self.assertEqual(G.edges["1", "2"], H.edges["1", "2"])
+        self.assertEqual(G.edges["2", "1"], H.edges["2", "1"])
 
     def test_degree_undirected(self):
         G1 = Graph(backend=NetworkXBackend(directed=False))


### PR DESCRIPTION
Closes #44

- use NetworkX `OutEdgeView` for directed backends and `EdgeView` for undirected backends
- preserve reciprocal directed edges in iteration, calls, and metadata lookup
- add regression coverage for both directions

Also I love that #88 closes #44, that feels somehow very good to me. Unfortunately #22 and #11 are totally unrelated.